### PR TITLE
Changes in pattern handling and improved logging.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   mode:
     required: false
     description: 'Optional. There are 2 modes for this action - _incremental_ and _complete_. If not specified, the action will use incremental mode by default. In incremental mode, the action will compare already exisiting policy in azure with the contents of policy provided in repository file. It will apply the policy only if there is a mismatch. On the contrary, the complete mode will apply all the files present in the specified paths irrespective of whether or not repository policy file has been updated.'
+  enforce:
+    required: false
+    description: 'Optional. To override the property enforcementMode in assignments. Input is similar to assignments input. Add ~ at the beginning if you do not want to enforce the assignment(s)'
 runs:
   using: 'node12'
   main: 'lib/run.js'

--- a/lib/inputProcessing/inputs.js
+++ b/lib/inputProcessing/inputs.js
@@ -19,22 +19,21 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.readInputs = exports.doNotEnforcePatterns = exports.enforcePatterns = exports.excludeAssignmentPatterns = exports.includeAssignmentPatterns = exports.excludePathPatterns = exports.includePathPatterns = exports.mode = exports.enforcementMode = exports.assignments = exports.ignorePaths = exports.paths = exports.MODE_COMPLETE = exports.MODE_INCREMENTAL = void 0;
+exports.readInputs = exports.doNotEnforcePatterns = exports.enforcePatterns = exports.assignmentPatterns = exports.excludePathPatterns = exports.includePathPatterns = exports.mode = exports.enforcementMode = exports.assignments = exports.ignorePaths = exports.paths = exports.MODE_COMPLETE = exports.MODE_INCREMENTAL = exports.INPUT_MODE = void 0;
 const core = __importStar(require("@actions/core"));
 const INPUT_PATHS_KEY = 'paths';
 const INPUT_IGNORE_PATHS_KEY = 'ignore-paths';
 const INPUT_ASSIGNMENTS_KEY = 'assignments';
 const INPUT_ENFORCEMENT_MODE_KEY = 'enforce';
-const INPUT_MODE = "mode";
-const EXCLUDE_PREFIX = '!';
+exports.INPUT_MODE = "mode";
+const DO_NOT_ENFORCE_PREFIX = '~';
 const DEFAULT_ASSIGNMENT_PATTERN = 'assign.*.json';
 exports.MODE_INCREMENTAL = "incremental";
 exports.MODE_COMPLETE = "complete";
 exports.mode = exports.MODE_INCREMENTAL;
 exports.includePathPatterns = [];
 exports.excludePathPatterns = [];
-exports.includeAssignmentPatterns = [];
-exports.excludeAssignmentPatterns = [];
+exports.assignmentPatterns = [];
 exports.enforcePatterns = [];
 exports.doNotEnforcePatterns = [];
 function readInputs() {
@@ -42,7 +41,7 @@ function readInputs() {
     const ignorePathsInput = core.getInput(INPUT_IGNORE_PATHS_KEY);
     const assignmentsInput = core.getInput(INPUT_ASSIGNMENTS_KEY);
     const enforcementModeInput = core.getInput(INPUT_ENFORCEMENT_MODE_KEY);
-    exports.mode = core.getInput(INPUT_MODE) ? core.getInput(INPUT_MODE).toLowerCase() : exports.MODE_INCREMENTAL;
+    exports.mode = core.getInput(exports.INPUT_MODE) ? core.getInput(exports.INPUT_MODE).toLowerCase() : exports.MODE_INCREMENTAL;
     exports.paths = getInputArray(pathsInput);
     exports.ignorePaths = getInputArray(ignorePathsInput);
     exports.assignments = getInputArray(assignmentsInput);
@@ -50,7 +49,7 @@ function readInputs() {
     validateAssignments();
     validateEnforcementMode();
     exports.paths.forEach(path => {
-        isExcludeInput(path) ? exports.excludePathPatterns.push(path.substring(1)) : exports.includePathPatterns.push(path);
+        exports.includePathPatterns.push(path);
     });
     if (exports.ignorePaths) {
         exports.ignorePaths.forEach(ignorePath => {
@@ -59,15 +58,15 @@ function readInputs() {
     }
     if (exports.assignments) {
         exports.assignments.forEach(assignment => {
-            isExcludeInput(assignment) ? exports.excludeAssignmentPatterns.push(assignment.substring(1)) : exports.includeAssignmentPatterns.push(assignment);
+            exports.assignmentPatterns.push(assignment);
         });
     }
-    if (exports.includeAssignmentPatterns.length == 0) {
-        exports.includeAssignmentPatterns.push(DEFAULT_ASSIGNMENT_PATTERN);
+    if (exports.assignmentPatterns.length == 0) {
+        exports.assignmentPatterns.push(DEFAULT_ASSIGNMENT_PATTERN);
     }
     if (exports.enforcementMode) {
         exports.enforcementMode.forEach(enforcementMode => {
-            isExcludeInput(enforcementMode)
+            enforcementMode.startsWith(DO_NOT_ENFORCE_PREFIX)
                 ? exports.doNotEnforcePatterns.push(enforcementMode.substring(1))
                 : exports.enforcePatterns.push(enforcementMode);
         });
@@ -77,18 +76,27 @@ exports.readInputs = readInputs;
 function getInputArray(input) {
     return input ? input.split('\n').map(item => item.trim()) : undefined;
 }
-function isExcludeInput(input) {
-    return input.startsWith(EXCLUDE_PREFIX);
-}
 function validateAssignments() {
-    if (exports.assignments && hasGlobStarPattern(exports.assignments)) {
-        throw Error(`Input '${INPUT_ASSIGNMENTS_KEY}' should not contain globstar pattern '**'.`);
-    }
+    validateAssignmentLikePatterns(INPUT_ASSIGNMENTS_KEY, exports.assignments);
 }
 function validateEnforcementMode() {
-    if (exports.enforcementMode && hasGlobStarPattern(exports.enforcementMode)) {
-        throw Error(`Input '${INPUT_ENFORCEMENT_MODE_KEY}' should not contain globstar pattern '**'.`);
+    validateAssignmentLikePatterns(INPUT_ENFORCEMENT_MODE_KEY, exports.enforcementMode);
+}
+function validateAssignmentLikePatterns(inputName, patterns) {
+    if (!patterns) {
+        return;
     }
+    if (hasSlashInPattern(patterns)) {
+        throw Error(`Input '${inputName}' should not contain directory separator '/' in any pattern.`);
+    }
+    if (hasGlobStarPattern(patterns)) {
+        throw Error(`Input '${inputName}' should not contain globstar '**' in any pattern.`);
+    }
+}
+function hasSlashInPattern(patterns) {
+    return patterns.some(pattern => {
+        return pattern.includes('/');
+    });
 }
 function hasGlobStarPattern(patterns) {
     return patterns.some(pattern => {

--- a/lib/inputProcessing/pathHelper.js
+++ b/lib/inputProcessing/pathHelper.js
@@ -36,7 +36,9 @@ const policyHelper_1 = require("../azure/policyHelper");
   *          3) Contain policy.json files.
   */
 function getAllPolicyDefinitionPaths() {
+    core.debug('Looking for policy definition paths to include...');
     const policyPathsToInclude = getPolicyPathsMatchingPatterns(Inputs.includePathPatterns, policyHelper_1.POLICY_FILE_NAME);
+    core.debug('Looking for policy definition paths to ignore...');
     const policyPathsToExclude = getPolicyPathsMatchingPatterns(Inputs.excludePathPatterns, policyHelper_1.POLICY_FILE_NAME);
     return policyPathsToInclude.filter(p => !policyPathsToExclude.includes(p));
 }
@@ -48,7 +50,9 @@ exports.getAllPolicyDefinitionPaths = getAllPolicyDefinitionPaths;
   *          3) Contain policyset.json files.
   */
 function getAllInitiativesPaths() {
+    core.debug('Looking for policy initiative paths to include...');
     const policyPathsToInclude = getPolicyPathsMatchingPatterns(Inputs.includePathPatterns, policyHelper_1.POLICY_INITIATIVE_FILE_NAME);
+    core.debug('Looking for policy initiative paths to ignore...');
     const policyPathsToExclude = getPolicyPathsMatchingPatterns(Inputs.excludePathPatterns, policyHelper_1.POLICY_INITIATIVE_FILE_NAME);
     return policyPathsToInclude.filter(p => !policyPathsToExclude.includes(p));
 }
@@ -65,14 +69,24 @@ function getAllPolicyAssignmentPaths() {
 }
 exports.getAllPolicyAssignmentPaths = getAllPolicyAssignmentPaths;
 function isEnforced(assignmentPath) {
+    core.debug(`Checking if assignment path '${assignmentPath}' is set to enforce`);
     return Inputs.enforcePatterns.some(pattern => {
-        return minimatch_1.default(assignmentPath, pattern, { dot: true, matchBase: true });
+        const isMatch = minimatch_1.default(assignmentPath, pattern, { dot: true, matchBase: true });
+        if (isMatch) {
+            core.debug(`Assignment path '${assignmentPath}' matches pattern '${pattern}' for enforce`);
+        }
+        return isMatch;
     });
 }
 exports.isEnforced = isEnforced;
 function isNonEnforced(assignmentPath) {
+    core.debug(`Checking if assignment path '${assignmentPath}' is set to do not enforce`);
     return Inputs.doNotEnforcePatterns.some(pattern => {
-        return minimatch_1.default(assignmentPath, pattern, { dot: true, matchBase: true });
+        const isMatch = minimatch_1.default(assignmentPath, pattern, { dot: true, matchBase: true });
+        if (isMatch) {
+            core.debug(`Assignment path '${assignmentPath}' matches pattern '~${pattern}' for do not enforce`);
+        }
+        return isMatch;
     });
 }
 exports.isNonEnforced = isNonEnforced;

--- a/lib/inputProcessing/pathHelper.js
+++ b/lib/inputProcessing/pathHelper.js
@@ -26,6 +26,7 @@ exports.isNonEnforced = exports.isEnforced = exports.getAllPolicyAssignmentPaths
 const glob = __importStar(require("glob"));
 const minimatch_1 = __importDefault(require("minimatch"));
 const path = __importStar(require("path"));
+const core = __importStar(require("@actions/core"));
 const Inputs = __importStar(require("./inputs"));
 const policyHelper_1 = require("../azure/policyHelper");
 /**
@@ -60,20 +61,18 @@ exports.getAllInitiativesPaths = getAllInitiativesPaths;
   *          4) File name matches any pattern given in assignments input.
   */
 function getAllPolicyAssignmentPaths() {
-    const assignmentPathsToInclude = getAssignmentPathsMatchingPatterns(Inputs.includePathPatterns, Inputs.includeAssignmentPatterns);
-    const assignmentPathsToExclude = getAssignmentPathsMatchingPatterns(Inputs.excludePathPatterns, Inputs.excludeAssignmentPatterns);
-    return assignmentPathsToInclude.filter(a => !assignmentPathsToExclude.includes(a));
+    return getAssignmentPathsMatchingPatterns(Inputs.includePathPatterns, Inputs.assignmentPatterns);
 }
 exports.getAllPolicyAssignmentPaths = getAllPolicyAssignmentPaths;
 function isEnforced(assignmentPath) {
     return Inputs.enforcePatterns.some(pattern => {
-        return minimatch_1.default(assignmentPath, pattern, { matchBase: true });
+        return minimatch_1.default(assignmentPath, pattern, { dot: true, matchBase: true });
     });
 }
 exports.isEnforced = isEnforced;
 function isNonEnforced(assignmentPath) {
     return Inputs.doNotEnforcePatterns.some(pattern => {
-        return minimatch_1.default(assignmentPath, pattern, { matchBase: true });
+        return minimatch_1.default(assignmentPath, pattern, { dot: true, matchBase: true });
     });
 }
 exports.isNonEnforced = isNonEnforced;
@@ -82,6 +81,7 @@ function getPolicyPathsMatchingPatterns(patterns, policyFileName) {
     patterns.forEach(pattern => {
         const policyFilePattern = path.join(pattern, policyFileName);
         const policyFiles = getFilesMatchingPattern(policyFilePattern);
+        core.debug(`Policy file pattern: ${policyFilePattern}\n Matching policy paths: ${policyFiles}`);
         matchingPolicyPaths.push(...policyFiles.map(policyFile => path.dirname(policyFile)));
     });
     return getUniquePaths(matchingPolicyPaths);
@@ -90,14 +90,16 @@ function getAssignmentPathsMatchingPatterns(patterns, assignmentPatterns) {
     let matchingAssignmentPaths = [];
     patterns.forEach(policyPath => {
         assignmentPatterns.forEach(assignmentPattern => {
-            const assignmentPaths = getFilesMatchingPattern(path.join(policyPath, assignmentPattern));
+            const pattern = path.join(policyPath, assignmentPattern);
+            const assignmentPaths = getFilesMatchingPattern(pattern);
+            core.debug(`Assignment pattern: ${pattern}\n Matching assignment paths: ${assignmentPaths}`);
             matchingAssignmentPaths.push(...assignmentPaths);
         });
     });
     return getUniquePaths(matchingAssignmentPaths);
 }
 function getFilesMatchingPattern(pattern) {
-    return glob.sync(pattern);
+    return glob.sync(pattern, { dot: true });
 }
 function getUniquePaths(paths) {
     return [...new Set(paths)];

--- a/lib/run.js
+++ b/lib/run.js
@@ -70,7 +70,14 @@ function setResult(policyResults) {
             core.info(`All policies deployed successfully. Created/updated '${policyResults.length}' definitions/assignments.`);
         }
         else {
-            core.warning(`Did not find any policies to create/update. Please ensure that policy definition files are named '${policyHelper_1.POLICY_FILE_NAME}' and policy initiative files are named '${policyHelper_1.POLICY_INITIATIVE_FILE_NAME}'. This can also happen if there is no change in policies AND '${Inputs.INPUT_MODE}' is not set to '${Inputs.MODE_COMPLETE}'.`);
+            let warningMessage;
+            if (Inputs.mode == Inputs.MODE_COMPLETE) {
+                warningMessage = `Did not find any policies to create/update. No policy files match the given patterns. If you have policy definitions or policy initiatives, please ensure that the files are named '${policyHelper_1.POLICY_FILE_NAME}' and '${policyHelper_1.POLICY_INITIATIVE_FILE_NAME}' respectively.`;
+            }
+            else {
+                warningMessage = `Did not find any policies to create/update. No policy files match the given patterns or no changes were detected. If you have policy definitions or policy initiatives, please ensure that the files are named '${policyHelper_1.POLICY_FILE_NAME}' and '${policyHelper_1.POLICY_INITIATIVE_FILE_NAME}' respectively.`;
+            }
+            core.warning(warningMessage);
         }
     }
 }

--- a/lib/run.js
+++ b/lib/run.js
@@ -70,7 +70,7 @@ function setResult(policyResults) {
             core.info(`All policies deployed successfully. Created/updated '${policyResults.length}' definitions/assignments.`);
         }
         else {
-            core.warning(`Did not find any policies to update. Please ensure that policy definition files are named policy.json. This can also happen if there is no change in policies and '${Inputs.INPUT_MODE}' is not set to '${Inputs.MODE_COMPLETE}'.`);
+            core.warning(`Did not find any policies to create/update. Please ensure that policy definition files are named '${policyHelper_1.POLICY_FILE_NAME}' and policy initiative files are named '${policyHelper_1.POLICY_INITIATIVE_FILE_NAME}'. This can also happen if there is no change in policies AND '${Inputs.INPUT_MODE}' is not set to '${Inputs.MODE_COMPLETE}'.`);
         }
     }
 }

--- a/lib/run.js
+++ b/lib/run.js
@@ -66,8 +66,11 @@ function setResult(policyResults) {
         if (failedCount > 0) {
             core.setFailed(`Found '${failedCount}' failure(s) while deploying policies.`);
         }
-        else {
+        else if (policyResults.length > 0) {
             core.info(`All policies deployed successfully. Created/updated '${policyResults.length}' definitions/assignments.`);
+        }
+        else {
+            core.warning(`Did not find any policies to update. Please ensure that policy definition files are named policy.json. This can also happen if there is no change in policies and '${Inputs.INPUT_MODE}' is not set to '${Inputs.MODE_COMPLETE}'.`);
         }
     }
 }

--- a/src/azure/policyHelper.ts
+++ b/src/azure/policyHelper.ts
@@ -389,7 +389,6 @@ function getPolicyOperationType(policyDetails: PolicyDetails, currentHash: strin
   //If user has chosen to push only updated files i.e 'mode' == Incremental AND a valid hash is available in policy metadata compare them.
   prettyDebugLog(`Comparing Hash for policy id : ${policyInCode.id} : ${azureHash === currentHash}`);
   return (azureHash === currentHash) ? POLICY_OPERATION_NONE : POLICY_OPERATION_UPDATE;
-
 }
 
 /**

--- a/src/inputProcessing/pathHelper.ts
+++ b/src/inputProcessing/pathHelper.ts
@@ -12,7 +12,9 @@ import { POLICY_FILE_NAME, POLICY_INITIATIVE_FILE_NAME } from '../azure/policyHe
   *          3) Contain policy.json files.
   */
 export function getAllPolicyDefinitionPaths(): string[] {
+  core.debug('Looking for policy definition paths to include...');
   const policyPathsToInclude = getPolicyPathsMatchingPatterns(Inputs.includePathPatterns, POLICY_FILE_NAME);
+  core.debug('Looking for policy definition paths to ignore...');
   const policyPathsToExclude = getPolicyPathsMatchingPatterns(Inputs.excludePathPatterns, POLICY_FILE_NAME);
   return policyPathsToInclude.filter(p => !policyPathsToExclude.includes(p));
 }
@@ -23,8 +25,10 @@ export function getAllPolicyDefinitionPaths(): string[] {
   *          2) Do not match any pattern given in ignore-paths input or pattern starting with '!' in path input.
   *          3) Contain policyset.json files.
   */
- export function getAllInitiativesPaths(): string[] {
+export function getAllInitiativesPaths(): string[] {
+  core.debug('Looking for policy initiative paths to include...');
   const policyPathsToInclude = getPolicyPathsMatchingPatterns(Inputs.includePathPatterns, POLICY_INITIATIVE_FILE_NAME);
+  core.debug('Looking for policy initiative paths to ignore...');
   const policyPathsToExclude = getPolicyPathsMatchingPatterns(Inputs.excludePathPatterns, POLICY_INITIATIVE_FILE_NAME);
   return policyPathsToInclude.filter(p => !policyPathsToExclude.includes(p));
 }
@@ -42,14 +46,24 @@ export function getAllPolicyAssignmentPaths(): string[] {
 }
 
 export function isEnforced(assignmentPath: string): boolean {
+  core.debug(`Checking if assignment path '${assignmentPath}' is set to enforce`);
   return Inputs.enforcePatterns.some(pattern => {
-    return minimatch(assignmentPath, pattern, { dot: true, matchBase: true });
+    const isMatch = minimatch(assignmentPath, pattern, { dot: true, matchBase: true });
+    if (isMatch) {
+      core.debug(`Assignment path '${assignmentPath}' matches pattern '${pattern}' for enforce`);
+    }
+    return isMatch;
   });
 }
 
 export function isNonEnforced(assignmentPath: string): boolean {
+  core.debug(`Checking if assignment path '${assignmentPath}' is set to do not enforce`);
   return Inputs.doNotEnforcePatterns.some(pattern => {
-    return minimatch(assignmentPath, pattern, { dot: true, matchBase: true });
+    const isMatch = minimatch(assignmentPath, pattern, { dot: true, matchBase: true });
+    if (isMatch) {
+      core.debug(`Assignment path '${assignmentPath}' matches pattern '~${pattern}' for do not enforce`);
+    }
+    return isMatch;
   });
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -36,11 +36,12 @@ function setResult(policyResults: PolicyResult[]): void {
     const failedCount: number = policyResults.filter(result => result.status === POLICY_RESULT_FAILED).length;
     if (failedCount > 0) {
       core.setFailed(`Found '${failedCount}' failure(s) while deploying policies.`);
-    } else {
+    } else if (policyResults.length > 0) {
       core.info(`All policies deployed successfully. Created/updated '${policyResults.length}' definitions/assignments.`);
+    } else {
+      core.warning(`Did not find any policies to update. Please ensure that policy definition files are named policy.json. This can also happen if there is no change in policies and '${Inputs.INPUT_MODE}' is not set to '${Inputs.MODE_COMPLETE}'.`);
     }
   }
-
 }
 
 run();

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,8 +1,8 @@
 import * as core from '@actions/core';
 import * as Inputs from './inputProcessing/inputs';
-import { POLICY_RESULT_FAILED, PolicyRequest, PolicyResult, createUpdatePolicies, getAllPolicyRequests } from './azure/policyHelper'
+import { POLICY_FILE_NAME, POLICY_INITIATIVE_FILE_NAME, POLICY_RESULT_FAILED, PolicyRequest, PolicyResult, createUpdatePolicies, getAllPolicyRequests } from './azure/policyHelper'
 import { printSummary } from './report/reportGenerator';
-import { prettyDebugLog, setUpUserAgent } from './utils/utilities'
+import { setUpUserAgent } from './utils/utilities'
 
 /**
  * Entry point for Action
@@ -39,7 +39,7 @@ function setResult(policyResults: PolicyResult[]): void {
     } else if (policyResults.length > 0) {
       core.info(`All policies deployed successfully. Created/updated '${policyResults.length}' definitions/assignments.`);
     } else {
-      core.warning(`Did not find any policies to update. Please ensure that policy definition files are named policy.json. This can also happen if there is no change in policies and '${Inputs.INPUT_MODE}' is not set to '${Inputs.MODE_COMPLETE}'.`);
+      core.warning(`Did not find any policies to create/update. Please ensure that policy definition files are named '${POLICY_FILE_NAME}' and policy initiative files are named '${POLICY_INITIATIVE_FILE_NAME}'. This can also happen if there is no change in policies AND '${Inputs.INPUT_MODE}' is not set to '${Inputs.MODE_COMPLETE}'.`);
     }
   }
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -39,7 +39,15 @@ function setResult(policyResults: PolicyResult[]): void {
     } else if (policyResults.length > 0) {
       core.info(`All policies deployed successfully. Created/updated '${policyResults.length}' definitions/assignments.`);
     } else {
-      core.warning(`Did not find any policies to create/update. Please ensure that policy definition files are named '${POLICY_FILE_NAME}' and policy initiative files are named '${POLICY_INITIATIVE_FILE_NAME}'. This can also happen if there is no change in policies AND '${Inputs.INPUT_MODE}' is not set to '${Inputs.MODE_COMPLETE}'.`);
+      let warningMessage: string;
+      if(Inputs.mode == Inputs.MODE_COMPLETE) {
+        warningMessage = `Did not find any policies to create/update. No policy files match the given patterns. If you have policy definitions or policy initiatives, please ensure that the files are named '${POLICY_FILE_NAME}' and '${POLICY_INITIATIVE_FILE_NAME}' respectively.`;
+      }
+      else {
+        warningMessage = `Did not find any policies to create/update. No policy files match the given patterns or no changes were detected. If you have policy definitions or policy initiatives, please ensure that the files are named '${POLICY_FILE_NAME}' and '${POLICY_INITIATIVE_FILE_NAME}' respectively.`;
+      }
+
+      core.warning(warningMessage);
     }
   }
 }


### PR DESCRIPTION
- Use `~` in `enforce` for `DoNotEnforce` patterns.
- Remove `!` special handling in `paths`/`assignments` patterns.
- Add debug logs in pattern matching.
- Add warning when no policies found to deploy.
- Treat `dot` in file paths with no special meaning.
- Block `/` in `assignment`/`enforce` patterns