### PR TITLE
Policy initiative support

### DIFF
--- a/lib/azure/azHttpClient.js
+++ b/lib/azure/azHttpClient.js
@@ -49,6 +49,11 @@ class AzHttpClient {
             return this.upsertPolicies(policyRequests);
         });
     }
+    upsertPolicyInitiatives(policyRequests) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.upsertPolicies(policyRequests);
+        });
+    }
     upsertPolicyAssignments(policyRequests) {
         return __awaiter(this, void 0, void 0, function* () {
             return this.upsertPolicies(policyRequests);

--- a/lib/azure/policyHelper.js
+++ b/lib/azure/policyHelper.js
@@ -28,7 +28,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.createUpdatePolicies = exports.getAllPolicyRequests = exports.POLICY_FILE_NAME = exports.POLICY_RESULT_SUCCEEDED = exports.POLICY_RESULT_FAILED = exports.POLICY_OPERATION_NONE = exports.POLICY_OPERATION_UPDATE = exports.POLICY_OPERATION_CREATE = exports.ASSIGNMENT_TYPE = exports.DEFINITION_TYPE = void 0;
+exports.createUpdatePolicies = exports.getAllPolicyRequests = exports.FRIENDLY_ASSIGNMENT_TYPE = exports.FRIENDLY_INITIATIVE_TYPE = exports.FRIENDLY_DEFINITION_TYPE = exports.POLICY_SET_FILE_NAME = exports.POLICY_FILE_NAME = exports.POLICY_RESULT_SUCCEEDED = exports.POLICY_RESULT_FAILED = exports.POLICY_OPERATION_NONE = exports.POLICY_OPERATION_UPDATE = exports.POLICY_OPERATION_CREATE = exports.ASSIGNMENT_TYPE = exports.INITIATIVE_TYPE = exports.DEFINITION_TYPE = void 0;
 const path = __importStar(require("path"));
 const core = __importStar(require("@actions/core"));
 const azHttpClient_1 = require("./azHttpClient");
@@ -38,6 +38,7 @@ const utilities_1 = require("../utils/utilities");
 const pathHelper_1 = require("../inputProcessing/pathHelper");
 const Inputs = __importStar(require("../inputProcessing/inputs"));
 exports.DEFINITION_TYPE = "Microsoft.Authorization/policyDefinitions";
+exports.INITIATIVE_TYPE = "Microsoft.Authorization/policySetDefinitions";
 exports.ASSIGNMENT_TYPE = "Microsoft.Authorization/policyAssignments";
 exports.POLICY_OPERATION_CREATE = "CREATE";
 exports.POLICY_OPERATION_UPDATE = "UPDATE";
@@ -45,10 +46,17 @@ exports.POLICY_OPERATION_NONE = "NONE";
 exports.POLICY_RESULT_FAILED = "FAILED";
 exports.POLICY_RESULT_SUCCEEDED = "SUCCEEDED";
 exports.POLICY_FILE_NAME = "policy.json";
+exports.POLICY_SET_FILE_NAME = "policyset.json";
+exports.FRIENDLY_DEFINITION_TYPE = "definition";
+exports.FRIENDLY_INITIATIVE_TYPE = "initiative";
+exports.FRIENDLY_ASSIGNMENT_TYPE = "assignment";
 const POLICY_RULES_FILE_NAME = "policy.rules.json";
 const POLICY_PARAMETERS_FILE_NAME = "policy.parameters.json";
+const POLICY_SET_PARAMETERS_FILE_NAME = "policyset.parameters.json";
+const POLICY_SET_DEFINITIONS_FILE_NAME = "policyset.definitions.json";
 const POLICY_DEFINITION_NOT_FOUND = "PolicyDefinitionNotFound";
 const POLICY_ASSIGNMENT_NOT_FOUND = "PolicyAssignmentNotFound";
+const POLICY_SET_DEFINITION_NOT_FOUND = "PolicySetDefinitionNotFound";
 const POLICY_METADATA_GITHUB_KEY = "gitHubPolicy";
 const POLICY_METADATA_HASH_KEY = "digest";
 const ENFORCEMENT_MODE_KEY = "enforcementMode";
@@ -65,7 +73,7 @@ function getAllPolicyRequests() {
                 const gitPolicy = policyDetails.policyInCode;
                 const currentHash = hashUtils_1.getObjectHash(gitPolicy);
                 const azurePolicy = policyDetails.policyInService;
-                if (azurePolicy.error && azurePolicy.error.code != POLICY_DEFINITION_NOT_FOUND && azurePolicy.error.code != POLICY_ASSIGNMENT_NOT_FOUND) {
+                if (azurePolicy.error && azurePolicy.error.code != POLICY_DEFINITION_NOT_FOUND && azurePolicy.error.code != POLICY_ASSIGNMENT_NOT_FOUND && azurePolicy.error.code != POLICY_SET_DEFINITION_NOT_FOUND) {
                     // There was some error while fetching the policy.
                     utilities_1.prettyLog(`Failed to get policy with id ${gitPolicy.id}, path ${policyDetails.path}. Error : ${JSON.stringify(azurePolicy.error)}`);
                 }
@@ -89,17 +97,39 @@ function createUpdatePolicies(policyRequests) {
         const azHttpClient = new azHttpClient_1.AzHttpClient();
         yield azHttpClient.initialize();
         let policyResults = [];
-        // Dividing policy requests into definitions and assignments.
-        const definitionRequests = policyRequests.filter(req => req.policy.type == exports.DEFINITION_TYPE);
-        const assignmentRequests = policyRequests.filter(req => req.policy.type == exports.ASSIGNMENT_TYPE);
+        // Dividing policy requests into definitions, initiatives and assignments.
+        const [definitionRequests, initiativeRequests, assignmentRequests] = dividePolicyRequests(policyRequests);
         const definitionResponses = yield azHttpClient.upsertPolicyDefinitions(definitionRequests);
-        policyResults.push(...getPolicyResults(definitionRequests, definitionResponses));
+        policyResults.push(...getPolicyResults(definitionRequests, definitionResponses, exports.FRIENDLY_DEFINITION_TYPE));
+        const initiativeResponses = yield azHttpClient.upsertPolicyInitiatives(initiativeRequests);
+        policyResults.push(...getPolicyResults(initiativeRequests, initiativeResponses, exports.FRIENDLY_INITIATIVE_TYPE));
         const assignmentResponses = yield azHttpClient.upsertPolicyAssignments(assignmentRequests);
-        policyResults.push(...getPolicyResults(assignmentRequests, assignmentResponses));
+        policyResults.push(...getPolicyResults(assignmentRequests, assignmentResponses, exports.FRIENDLY_ASSIGNMENT_TYPE));
         return Promise.resolve(policyResults);
     });
 }
 exports.createUpdatePolicies = createUpdatePolicies;
+function dividePolicyRequests(policyRequests) {
+    let definitionRequests = [];
+    let initiativeRequests = [];
+    let assignmentRequests = [];
+    policyRequests.forEach(policyRequest => {
+        switch (policyRequest.policy.type) {
+            case exports.DEFINITION_TYPE:
+                definitionRequests.push(policyRequest);
+                break;
+            case exports.INITIATIVE_TYPE:
+                initiativeRequests.push(policyRequest);
+                break;
+            case exports.ASSIGNMENT_TYPE:
+                assignmentRequests.push(policyRequest);
+                break;
+            default:
+                utilities_1.prettyDebugLog(`Unknown type for policy in path : ${policyRequest.path}`);
+        }
+    });
+    return [definitionRequests, initiativeRequests, assignmentRequests];
+}
 function getPolicyDefinition(definitionPath) {
     const policyPath = path.join(definitionPath, exports.POLICY_FILE_NAME);
     const policyRulesPath = path.join(definitionPath, POLICY_RULES_FILE_NAME);
@@ -127,8 +157,38 @@ function getPolicyDefinition(definitionPath) {
             definition.properties.parameters = policyParametersJson.parameters;
         }
     }
-    validateDefinition(definition, definitionPath);
+    validatePolicy(definition, definitionPath, exports.FRIENDLY_DEFINITION_TYPE);
     return definition;
+}
+function getPolicyInitiative(initiativePath) {
+    const policySetPath = path.join(initiativePath, exports.POLICY_SET_FILE_NAME);
+    const policySetParametersPath = path.join(initiativePath, POLICY_SET_PARAMETERS_FILE_NAME);
+    const policySetDefinitionsPath = path.join(initiativePath, POLICY_SET_DEFINITIONS_FILE_NAME);
+    let initiative = fileHelper_1.getFileJson(policySetPath);
+    if ((!initiative.properties || !initiative.properties.policyDefinitions) && fileHelper_1.doesFileExist(policySetDefinitionsPath)) {
+        const policySetDefinitionsJson = fileHelper_1.getFileJson(policySetDefinitionsPath);
+        if (policySetDefinitionsJson) {
+            if (!initiative.properties) {
+                // If properties is missing from the initiative object and we obtain policyDefinitions from the
+                // policyDefinitions file, add properties.
+                initiative.properties = {};
+            }
+            initiative.properties.policyDefinitions = policySetDefinitionsJson;
+        }
+    }
+    if ((!initiative.properties || !initiative.properties.parameters) && fileHelper_1.doesFileExist(policySetParametersPath)) {
+        const policySetParametersJson = fileHelper_1.getFileJson(policySetParametersPath);
+        if (policySetParametersJson) {
+            if (!initiative.properties) {
+                // If properties is missing from the initiative object and we obtain parameters from the
+                // policy parameters file, add properties.
+                initiative.properties = {};
+            }
+            initiative.properties.parameters = policySetParametersJson;
+        }
+    }
+    validatePolicy(initiative, initiativePath, exports.FRIENDLY_INITIATIVE_TYPE);
+    return initiative;
 }
 function getPolicyAssignment(assignmentPath) {
     const assignment = fileHelper_1.getFileJson(assignmentPath);
@@ -146,16 +206,15 @@ function getPolicyAssignment(assignmentPath) {
         core.debug(`Assignment path: ${assignmentPath} matches enforcementMode pattern for '${ENFORCEMENT_MODE_ENFORCE}'. Overriding...`);
         assignment.properties[ENFORCEMENT_MODE_KEY] = ENFORCEMENT_MODE_ENFORCE;
     }
-    validateAssignment(assignment, assignmentPath);
+    validatePolicy(assignment, assignmentPath, exports.FRIENDLY_ASSIGNMENT_TYPE);
     return assignment;
 }
-function getPolicyResults(policyRequests, policyResponses) {
+function getPolicyResults(policyRequests, policyResponses, policyType) {
     let policyResults = [];
     policyRequests.forEach((policyRequest, index) => {
         const isCreate = isCreateOperation(policyRequest);
         const azureResponse = policyResponses[index];
-        const policyType = policyRequest.policy.type == exports.DEFINITION_TYPE ? 'definition' : 'assignment';
-        const policyDefinitionId = policyRequest.policy.type == exports.DEFINITION_TYPE ? policyRequest.policy.id : policyRequest.policy.properties.policyDefinitionId;
+        const policyDefinitionId = policyRequest.policy.type == exports.ASSIGNMENT_TYPE ? policyRequest.policy.properties.policyDefinitionId : policyRequest.policy.id;
         let status = "";
         let message = "";
         if (!azureResponse) {
@@ -185,26 +244,15 @@ function getPolicyResults(policyRequests, policyResponses) {
 function isCreateOperation(policyRequest) {
     return policyRequest.operation == exports.POLICY_OPERATION_CREATE;
 }
-function validateDefinition(definition, path) {
-    if (!definition.id) {
-        throw Error(`Path : ${path}. Property id is missing from the policy definition. Please add id to the policy.json file.`);
+function validatePolicy(policy, path, type) {
+    if (!policy.id) {
+        throw Error(`Path : ${path}. Property id is missing from the policy ${type}. Please add id to the ${type} file.`);
     }
-    if (!definition.name) {
-        throw Error(`Path : ${path}. Property name is missing from the policy definition. Please add name to the policy.json file.`);
+    if (!policy.name) {
+        throw Error(`Path : ${path}. Property name is missing from the policy ${type}. Please add name to the ${type} file.`);
     }
-    if (!definition.type) {
-        throw Error(`Path : ${path}. Property type is missing from the policy definition. Please add type to the policy.json file.`);
-    }
-}
-function validateAssignment(assignment, path) {
-    if (!assignment.id) {
-        throw Error(`Path : ${path}. Property id is missing from the policy assignment. Please add id to the assignment file.`);
-    }
-    if (!assignment.name) {
-        throw Error(`Path : ${path}. Property name is missing from the policy assignment. Please add name to the assignment file.`);
-    }
-    if (!assignment.type) {
-        throw Error(`Path : ${path}. Property type is missing from the policy assignment. Please add type to the assignment file.`);
+    if (!policy.type) {
+        throw Error(`Path : ${path}. Property type is missing from the policy ${type}. Please add type to the ${type} file.`);
     }
 }
 // Returns all policy definitions and assignments.
@@ -212,7 +260,8 @@ function getAllPolicyDetails() {
     return __awaiter(this, void 0, void 0, function* () {
         let allPolicyDetails = [];
         const definitionPaths = pathHelper_1.getAllPolicyDefinitionPaths();
-        const assignmentPaths = pathHelper_1.getAllPolicyAssignmentPaths(definitionPaths);
+        const initiativePaths = pathHelper_1.getAllInitiativesPaths();
+        const assignmentPaths = pathHelper_1.getAllPolicyAssignmentPaths([...definitionPaths, ...initiativePaths]);
         definitionPaths.forEach(definitionPath => {
             const definition = getPolicyDefinition(definitionPath);
             if (definition.properties && definition.properties.policyType == POLICY_DEFINITION_BUILTIN) {
@@ -222,6 +271,18 @@ function getAllPolicyDetails() {
                 allPolicyDetails.push({
                     path: definitionPath,
                     policyInCode: definition
+                });
+            }
+        });
+        initiativePaths.forEach(initiativePath => {
+            const initiative = getPolicyInitiative(initiativePath);
+            if (initiative.properties && initiative.properties.policyType == POLICY_DEFINITION_BUILTIN) {
+                utilities_1.prettyDebugLog(`Ignoring policy initiative with BuiltIn type. Id : ${initiative.id}, path : ${initiativePath}`);
+            }
+            else {
+                allPolicyDetails.push({
+                    path: initiativePath,
+                    policyInCode: initiative
                 });
             }
         });

--- a/lib/inputProcessing/pathHelper.js
+++ b/lib/inputProcessing/pathHelper.js
@@ -22,7 +22,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isNonEnforced = exports.isEnforced = exports.getAllPolicyAssignmentPaths = exports.getAllPolicyDefinitionPaths = void 0;
+exports.isNonEnforced = exports.isEnforced = exports.getAllPolicyAssignmentPaths = exports.getAllInitiativesPaths = exports.getAllPolicyDefinitionPaths = void 0;
 const glob = __importStar(require("glob"));
 const minimatch_1 = __importDefault(require("minimatch"));
 const path = __importStar(require("path"));
@@ -35,11 +35,23 @@ const policyHelper_1 = require("../azure/policyHelper");
   *          3) Contain policy.json files.
   */
 function getAllPolicyDefinitionPaths() {
-    const policyPathsToInclude = getPolicyPathsMatchingPatterns(Inputs.includePathPatterns);
-    const policyPathsToExclude = getPolicyPathsMatchingPatterns(Inputs.excludePathPatterns);
+    const policyPathsToInclude = getPolicyPathsMatchingPatterns(Inputs.includePathPatterns, policyHelper_1.POLICY_FILE_NAME);
+    const policyPathsToExclude = getPolicyPathsMatchingPatterns(Inputs.excludePathPatterns, policyHelper_1.POLICY_FILE_NAME);
     return policyPathsToInclude.filter(p => !policyPathsToExclude.includes(p));
 }
 exports.getAllPolicyDefinitionPaths = getAllPolicyDefinitionPaths;
+/**
+  * @returns All the directories that:
+  *          1) Match any pattern given in paths input.
+  *          2) Do not match any pattern given in ignore-paths input or pattern starting with '!' in path input.
+  *          3) Contain policyset.json files.
+  */
+function getAllInitiativesPaths() {
+    const policyPathsToInclude = getPolicyPathsMatchingPatterns(Inputs.includePathPatterns, policyHelper_1.POLICY_SET_FILE_NAME);
+    const policyPathsToExclude = getPolicyPathsMatchingPatterns(Inputs.excludePathPatterns, policyHelper_1.POLICY_SET_FILE_NAME);
+    return policyPathsToInclude.filter(p => !policyPathsToExclude.includes(p));
+}
+exports.getAllInitiativesPaths = getAllInitiativesPaths;
 /**
   * @returns All the files that:
   *          1) Match any pattern given in paths input.
@@ -65,10 +77,10 @@ function isNonEnforced(assignmentPath) {
     });
 }
 exports.isNonEnforced = isNonEnforced;
-function getPolicyPathsMatchingPatterns(patterns) {
+function getPolicyPathsMatchingPatterns(patterns, policyFileName) {
     let matchingPolicyPaths = [];
     patterns.forEach(pattern => {
-        const policyFilePattern = path.join(pattern, policyHelper_1.POLICY_FILE_NAME);
+        const policyFilePattern = path.join(pattern, policyFileName);
         const policyFiles = getFilesMatchingPattern(policyFilePattern);
         matchingPolicyPaths.push(...policyFiles.map(policyFile => path.dirname(policyFile)));
     });

--- a/src/azure/azHttpClient.ts
+++ b/src/azure/azHttpClient.ts
@@ -51,6 +51,10 @@ export class AzHttpClient {
     return this.upsertPolicies(policyRequests);
   }
 
+  async upsertPolicyInitiatives(policyRequests: PolicyRequest[]): Promise<any[]> {
+    return this.upsertPolicies(policyRequests);
+  }
+
   async upsertPolicyAssignments(policyRequests: PolicyRequest[]): Promise<any[]> {
     return this.upsertPolicies(policyRequests);
   }


### PR DESCRIPTION
**Policy initiative support**

Policy initiatives are similar to policy definitions except instead of rules field we have policyDefinitions field.

Assignments of policy initiatives/ definitions are same so no special handling is required. 

Note : This does not handle tricky situations when policy definition is updated and initiative becomes invalid(not sure if this happens).