### PR TITLE
Improve warning message and debug logs. Fixes #31

### DIFF
--- a/lib/inputProcessing/pathHelper.js
+++ b/lib/inputProcessing/pathHelper.js
@@ -29,6 +29,7 @@ const path = __importStar(require("path"));
 const core = __importStar(require("@actions/core"));
 const Inputs = __importStar(require("./inputs"));
 const policyHelper_1 = require("../azure/policyHelper");
+const utilities_1 = require("../utils/utilities");
 /**
   * @returns All the directories that:
   *          1) Match any pattern given in paths input.
@@ -40,7 +41,12 @@ function getAllPolicyDefinitionPaths() {
     const policyPathsToInclude = getPolicyPathsMatchingPatterns(Inputs.includePathPatterns, policyHelper_1.POLICY_FILE_NAME);
     core.debug('Looking for policy definition paths to ignore...');
     const policyPathsToExclude = getPolicyPathsMatchingPatterns(Inputs.excludePathPatterns, policyHelper_1.POLICY_FILE_NAME);
-    return policyPathsToInclude.filter(p => !policyPathsToExclude.includes(p));
+    const policyPaths = policyPathsToInclude.filter(p => !policyPathsToExclude.includes(p));
+    const debugMessage = policyPaths.length > 0
+        ? `Found the following policy paths that match the given path filters:\n\n${policyPaths.join('\n')}`
+        : `Found no policies that match the given path filters.`;
+    utilities_1.prettyDebugLog(debugMessage);
+    return policyPaths;
 }
 exports.getAllPolicyDefinitionPaths = getAllPolicyDefinitionPaths;
 /**
@@ -51,10 +57,15 @@ exports.getAllPolicyDefinitionPaths = getAllPolicyDefinitionPaths;
   */
 function getAllInitiativesPaths() {
     core.debug('Looking for policy initiative paths to include...');
-    const policyPathsToInclude = getPolicyPathsMatchingPatterns(Inputs.includePathPatterns, policyHelper_1.POLICY_INITIATIVE_FILE_NAME);
+    const policyInitiativePathsToInclude = getPolicyPathsMatchingPatterns(Inputs.includePathPatterns, policyHelper_1.POLICY_INITIATIVE_FILE_NAME);
     core.debug('Looking for policy initiative paths to ignore...');
-    const policyPathsToExclude = getPolicyPathsMatchingPatterns(Inputs.excludePathPatterns, policyHelper_1.POLICY_INITIATIVE_FILE_NAME);
-    return policyPathsToInclude.filter(p => !policyPathsToExclude.includes(p));
+    const policyInitiativePathsToExclude = getPolicyPathsMatchingPatterns(Inputs.excludePathPatterns, policyHelper_1.POLICY_INITIATIVE_FILE_NAME);
+    const policyInitiativePaths = policyInitiativePathsToInclude.filter(p => !policyInitiativePathsToExclude.includes(p));
+    const debugMessage = policyInitiativePaths.length > 0
+        ? `Found the following policy initiative paths that match the given path filters:\n\n${policyInitiativePaths.join('\n')}`
+        : `Found no policy initiatives that match the given path filters.`;
+    utilities_1.prettyDebugLog(debugMessage);
+    return policyInitiativePaths;
 }
 exports.getAllInitiativesPaths = getAllInitiativesPaths;
 /**
@@ -69,7 +80,12 @@ function getAllPolicyAssignmentPaths() {
     const assignmentPathsToInclude = getAssignmentPathsMatchingPatterns(Inputs.includePathPatterns, Inputs.assignmentPatterns);
     core.debug('Looking for policy assignment paths to ignore...');
     const assignmentPathsToExclude = getAssignmentPathsMatchingPatterns(Inputs.excludePathPatterns, Inputs.assignmentPatterns);
-    return assignmentPathsToInclude.filter(p => !assignmentPathsToExclude.includes(p));
+    const assignmentPaths = assignmentPathsToInclude.filter(p => !assignmentPathsToExclude.includes(p));
+    const debugMessage = assignmentPaths.length > 0
+        ? `Found the following policy assignment paths that match the given path filters:\n\n${assignmentPaths.join('\n')}`
+        : `Found no policy assignments that match the given path filters.`;
+    utilities_1.prettyDebugLog(debugMessage);
+    return assignmentPaths;
 }
 exports.getAllPolicyAssignmentPaths = getAllPolicyAssignmentPaths;
 function getAllAssignmentInPaths(definitionFolderPaths) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -73,10 +73,10 @@ function setResult(policyResults) {
         else {
             let warningMessage;
             if (Inputs.mode == Inputs.MODE_COMPLETE) {
-                warningMessage = `Did not find any policies to create/update. No policy files match the given patterns. If you have policy definitions or policy initiatives, please ensure that the files are named '${policyHelper_1.POLICY_FILE_NAME}' and '${policyHelper_1.POLICY_INITIATIVE_FILE_NAME}' respectively.`;
+                warningMessage = `Did not find any policies to create/update. No policy files match the given patterns. If you have policy definitions or policy initiatives, please ensure that the files are named '${policyHelper_1.POLICY_FILE_NAME}' and '${policyHelper_1.POLICY_INITIATIVE_FILE_NAME}' respectively. For more details, please enable debug logs by adding secret 'ACTIONS_STEP_DEBUG' with value 'true'. (https://docs.github.com/en/actions/managing-workflow-runs/enabling-debug-logging#enabling-step-debug-logging)`;
             }
             else {
-                warningMessage = `Did not find any policies to create/update. No policy files match the given patterns or no changes were detected. If you have policy definitions or policy initiatives, please ensure that the files are named '${policyHelper_1.POLICY_FILE_NAME}' and '${policyHelper_1.POLICY_INITIATIVE_FILE_NAME}' respectively.`;
+                warningMessage = `Did not find any policies to create/update. No policy files match the given patterns or no changes were detected. If you have policy definitions or policy initiatives, please ensure that the files are named '${policyHelper_1.POLICY_FILE_NAME}' and '${policyHelper_1.POLICY_INITIATIVE_FILE_NAME}' respectively. For more details, please enable debug logs by adding secret 'ACTIONS_STEP_DEBUG' with value 'true'. (https://docs.github.com/en/actions/managing-workflow-runs/enabling-debug-logging#enabling-step-debug-logging)`;
             }
             core.warning(warningMessage);
         }

--- a/src/inputProcessing/pathHelper.ts
+++ b/src/inputProcessing/pathHelper.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as core from '@actions/core';
 import * as Inputs from './inputs';
 import { POLICY_FILE_NAME, POLICY_INITIATIVE_FILE_NAME } from '../azure/policyHelper';
+import { prettyDebugLog } from '../utils/utilities';
 
 /**
   * @returns All the directories that:
@@ -16,7 +17,12 @@ export function getAllPolicyDefinitionPaths(): string[] {
   const policyPathsToInclude = getPolicyPathsMatchingPatterns(Inputs.includePathPatterns, POLICY_FILE_NAME);
   core.debug('Looking for policy definition paths to ignore...');
   const policyPathsToExclude = getPolicyPathsMatchingPatterns(Inputs.excludePathPatterns, POLICY_FILE_NAME);
-  return policyPathsToInclude.filter(p => !policyPathsToExclude.includes(p));
+  const policyPaths = policyPathsToInclude.filter(p => !policyPathsToExclude.includes(p));
+  const debugMessage = policyPaths.length > 0
+    ? `Found the following policy paths that match the given path filters:\n\n${policyPaths.join('\n')}`
+    : `Found no policies that match the given path filters.`;
+  prettyDebugLog(debugMessage);
+  return policyPaths;
 }
 
 /**
@@ -27,10 +33,15 @@ export function getAllPolicyDefinitionPaths(): string[] {
   */
 export function getAllInitiativesPaths(): string[] {
   core.debug('Looking for policy initiative paths to include...');
-  const policyPathsToInclude = getPolicyPathsMatchingPatterns(Inputs.includePathPatterns, POLICY_INITIATIVE_FILE_NAME);
+  const policyInitiativePathsToInclude = getPolicyPathsMatchingPatterns(Inputs.includePathPatterns, POLICY_INITIATIVE_FILE_NAME);
   core.debug('Looking for policy initiative paths to ignore...');
-  const policyPathsToExclude = getPolicyPathsMatchingPatterns(Inputs.excludePathPatterns, POLICY_INITIATIVE_FILE_NAME);
-  return policyPathsToInclude.filter(p => !policyPathsToExclude.includes(p));
+  const policyInitiativePathsToExclude = getPolicyPathsMatchingPatterns(Inputs.excludePathPatterns, POLICY_INITIATIVE_FILE_NAME);
+  const policyInitiativePaths = policyInitiativePathsToInclude.filter(p => !policyInitiativePathsToExclude.includes(p));
+  const debugMessage = policyInitiativePaths.length > 0
+    ? `Found the following policy initiative paths that match the given path filters:\n\n${policyInitiativePaths.join('\n')}`
+    : `Found no policy initiatives that match the given path filters.`;
+  prettyDebugLog(debugMessage);
+  return policyInitiativePaths;
 }
 
 /**
@@ -46,7 +57,12 @@ export function getAllPolicyAssignmentPaths(): string[] {
   const assignmentPathsToInclude = getAssignmentPathsMatchingPatterns(Inputs.includePathPatterns, Inputs.assignmentPatterns);
   core.debug('Looking for policy assignment paths to ignore...');
   const assignmentPathsToExclude = getAssignmentPathsMatchingPatterns(Inputs.excludePathPatterns, Inputs.assignmentPatterns);
-  return assignmentPathsToInclude.filter(p => !assignmentPathsToExclude.includes(p));
+  const assignmentPaths = assignmentPathsToInclude.filter(p => !assignmentPathsToExclude.includes(p));
+  const debugMessage = assignmentPaths.length > 0
+    ? `Found the following policy assignment paths that match the given path filters:\n\n${assignmentPaths.join('\n')}`
+    : `Found no policy assignments that match the given path filters.`;
+  prettyDebugLog(debugMessage);
+  return assignmentPaths;
 }
 
 export function getAllAssignmentInPaths(definitionFolderPaths: string[]): string[] {

--- a/src/run.ts
+++ b/src/run.ts
@@ -42,10 +42,10 @@ function setResult(policyResults: PolicyResult[]): void {
     } else {
       let warningMessage: string;
       if(Inputs.mode == Inputs.MODE_COMPLETE) {
-        warningMessage = `Did not find any policies to create/update. No policy files match the given patterns. If you have policy definitions or policy initiatives, please ensure that the files are named '${POLICY_FILE_NAME}' and '${POLICY_INITIATIVE_FILE_NAME}' respectively.`;
+        warningMessage = `Did not find any policies to create/update. No policy files match the given patterns. If you have policy definitions or policy initiatives, please ensure that the files are named '${POLICY_FILE_NAME}' and '${POLICY_INITIATIVE_FILE_NAME}' respectively. For more details, please enable debug logs by adding secret 'ACTIONS_STEP_DEBUG' with value 'true'. (https://docs.github.com/en/actions/managing-workflow-runs/enabling-debug-logging#enabling-step-debug-logging)`;
       }
       else {
-        warningMessage = `Did not find any policies to create/update. No policy files match the given patterns or no changes were detected. If you have policy definitions or policy initiatives, please ensure that the files are named '${POLICY_FILE_NAME}' and '${POLICY_INITIATIVE_FILE_NAME}' respectively.`;
+        warningMessage = `Did not find any policies to create/update. No policy files match the given patterns or no changes were detected. If you have policy definitions or policy initiatives, please ensure that the files are named '${POLICY_FILE_NAME}' and '${POLICY_INITIATIVE_FILE_NAME}' respectively. For more details, please enable debug logs by adding secret 'ACTIONS_STEP_DEBUG' with value 'true'. (https://docs.github.com/en/actions/managing-workflow-runs/enabling-debug-logging#enabling-step-debug-logging)`;
       }
 
       core.warning(warningMessage);


### PR DESCRIPTION
Fixing #31.
- Suggest enabling debug logs in warning
   <img width="980" alt="image" src="https://user-images.githubusercontent.com/11447401/111278669-cfb9af80-865f-11eb-891d-bfb20f5da671.png">

- Add summary about path matching result in debug logs:
  - Policies not found
  
     <img width="925" alt="image" src="https://user-images.githubusercontent.com/11447401/111278836-07c0f280-8660-11eb-924f-0dc39b7b3ca8.png">

  - Policies found

     <img width="1036" alt="image" src="https://user-images.githubusercontent.com/11447401/111279111-59697d00-8660-11eb-992c-d66e1a45368d.png">
