### PR TITLE
Fixing tests to accommodate changes in pathHelper.

### DIFF
--- a/__tests__/pathHelper.test.ts
+++ b/__tests__/pathHelper.test.ts
@@ -68,13 +68,15 @@ describe('Testing all functions in pathHelper file', () => {
 				path.join('policies2', 'ignorePolicies', 'assign.three.json'),
 				path.join('policies2', 'somePolicies', 'assign.four.json')
 			];
+			if (pattern == path.join('policies2', 'ignorePolicies', '**', 'assign.*.json')) return [
+				path.join('policies2', 'ignorePolicies', 'assign.three.json')
+			];
 		});
 		jest.spyOn(core, 'debug').mockImplementation();
 
 		expect(pathHelper.getAllPolicyAssignmentPaths()).toMatchObject([
 			path.join('policies1', 'somePolicies', 'assign.one.json'),
 			path.join('policies1', 'assign.two.json'),
-			path.join('policies2', 'ignorePolicies', 'assign.three.json'),
 			path.join('policies2', 'somePolicies', 'assign.four.json'),
 		]);
 	});


### PR DESCRIPTION
Test was failing as a [commit](https://github.com/Azure/manage-azure-policy/commit/4a5aa31a1174ab9e9e7d295438cb5015bc5c2781) had been made since my fork and I hadn't updated it. 